### PR TITLE
Fix more secure crypto comment

### DIFF
--- a/libs/model/user.js
+++ b/libs/model/user.js
@@ -25,7 +25,7 @@ var mongoose = require('mongoose'),
 
 User.methods.encryptPassword = function(password) {
 	return crypto.createHmac('sha1', this.salt).update(password).digest('hex');
-    //more secure - return crypto.pbkdf2Sync(password, this.salt, 10000, 512).toString('base64').replace(/\//g,'_').replace(/\+/g,'-');
+    //more secure - return crypto.pbkdf2Sync(password, this.salt, 10000, 512).toString('hex');
 };
 
 User.virtual('userId')

--- a/libs/model/user.js
+++ b/libs/model/user.js
@@ -25,7 +25,7 @@ var mongoose = require('mongoose'),
 
 User.methods.encryptPassword = function(password) {
 	return crypto.createHmac('sha1', this.salt).update(password).digest('hex');
-    //more secure - return crypto.pbkdf2Sync(password, this.salt, 10000, 512).toString('base64');
+    //more secure - return crypto.pbkdf2Sync(password, this.salt, 10000, 512).toString('base64').replace(/\//g,'_').replace(/\+/g,'-');
 };
 
 User.virtual('userId')

--- a/libs/model/user.js
+++ b/libs/model/user.js
@@ -25,7 +25,7 @@ var mongoose = require('mongoose'),
 
 User.methods.encryptPassword = function(password) {
 	return crypto.createHmac('sha1', this.salt).update(password).digest('hex');
-    //more secure - return crypto.pbkdf2Sync(password, this.salt, 10000, 512);
+    //more secure - return crypto.pbkdf2Sync(password, this.salt, 10000, 512).toString('base64');
 };
 
 User.virtual('userId')


### PR DESCRIPTION
Without conversion to a string, I'm pretty sure the result of `pbkdf2Sync` is binary data. At any rate, it was failing until I added on `toString('base64')`.