### PR TITLE
Use port settings from the shell environment when available

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -6,9 +6,9 @@ var config = require(libs + 'config');
 var log = require(libs + 'log')(module);
 var app = require(libs + 'app');
 
-app.set('port', config.get('port') || 3000);
+app.set('port', process.env.PORT || config.get('port') || 3000);
 
 var server = app.listen(app.get('port'), function() {
-  debug('Express server listening on port ' + server.address().port);
-  log.info('Express server listening on port ' + config.get('port'));
+  debug('Express server listening on port ' + app.get('port'));
+  log.info('Express server listening on port ' + app.get('port'));
 });


### PR DESCRIPTION
For compatibility with Heroku, etc.